### PR TITLE
DEVOPS-56 Create "Publish" workflow to upload to S3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,5 +45,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.BOT_SECRET_KEY }}
           AWS_S3_BUCKET: ${{ secrets.S3_BUCKET }}
           AWS_REGION: 'eu-west-1'
-          SOURCE_DIR: 'complete/metadata.json'
+          SOURCE_DIR: 'complete'
           DEST_DIR: ${{ env.DESTINATION }}


### PR DESCRIPTION
Parts of the workflow `publish.yaml` are still up for discussion, but I need the file on the master branch so I can properly test the triggers. GH Actions doesn’t seem to pickup all newly pushed tags while the workflow file is not on the `master`.
[Here is how the destination will look like right now.](https://github.com/dhis2-metadata/COVAC-Registry-tracker/runs/2737660753?check_suite_focus=true#step:5:14)

The AWS credentials are currently stored as both Org and Repo Secrets (two different sets of credentials), so the repository can still be Private (Repo secrets overwrite Org ones), but once we start "applying" this workflow to the other repositories we would have to make them Public in order to use the Org Secrets.

Note that there are a lot of commits due to intermittent testing of the triggers and figuring out the proper syntax (as shell script could be tricky to get right after YAML parsing).

@Philip-Larsen-Donnelly @stratosilva @morten-devotta I can't add all of you guys as reviewers (only 1 allowed), but I can mention you. 😅 

